### PR TITLE
test: dynamic port in cluster worker dgram

### DIFF
--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -49,7 +49,7 @@ function master() {
     cluster.fork();
 
   // Wait until all workers are listening.
-  cluster.on('listening', common.mustCall(() => {
+  cluster.on('listening', common.mustCall((worker, address) => {
     if (++listening < NUM_WORKERS)
       return;
 
@@ -60,7 +60,7 @@ function master() {
     doSend();
 
     function doSend() {
-      socket.send(buf, 0, buf.length, common.PORT, '127.0.0.1', afterSend);
+      socket.send(buf, 0, buf.length, address.port, address.address, afterSend);
     }
 
     function afterSend() {
@@ -111,5 +111,5 @@ function worker() {
     }
   }, PACKETS_PER_WORKER));
 
-  socket.bind(common.PORT);
+  socket.bind(0);
 }

--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -26,6 +26,7 @@ const PACKETS_PER_WORKER = 10;
 
 const cluster = require('cluster');
 const dgram = require('dgram');
+const assert = require('assert');
 
 
 if (common.isWindows) {
@@ -45,7 +46,14 @@ function master() {
 
   // Start listening on a socket.
   const socket = dgram.createSocket('udp4');
-  socket.bind(common.PORT);
+  socket.bind({ port: 0 }, common.mustCall(() => {
+
+    // Fork workers.
+    for (let i = 0; i < NUM_WORKERS; i++) {
+      const worker = cluster.fork();
+      worker.send({ port: socket.address().port });
+    }
+  }));
 
   // Disconnect workers when the expected number of messages have been
   // received.
@@ -61,10 +69,6 @@ function master() {
       cluster.disconnect();
     }
   }, NUM_WORKERS * PACKETS_PER_WORKER));
-
-  // Fork workers.
-  for (let i = 0; i < NUM_WORKERS; i++)
-    cluster.fork();
 }
 
 
@@ -78,13 +82,17 @@ function worker() {
   // send(), explicitly bind them to an ephemeral port.
   socket.bind(0);
 
-  // There is no guarantee that a sent dgram packet will be received so keep
-  // sending until disconnect.
-  const interval = setInterval(() => {
-    socket.send(buf, 0, buf.length, common.PORT, '127.0.0.1');
-  }, 1);
+  process.on('message', common.mustCall((msg) => {
+    assert(msg.port);
 
-  cluster.worker.on('disconnect', () => {
-    clearInterval(interval);
-  });
+    // There is no guarantee that a sent dgram packet will be received so keep
+    // sending until disconnect.
+    const interval = setInterval(() => {
+      socket.send(buf, 0, buf.length, msg.port, '127.0.0.1');
+    }, 1);
+
+    cluster.worker.on('disconnect', () => {
+      clearInterval(interval);
+    });
+  }));
 }


### PR DESCRIPTION
Remove common.PORT from test-cluster-dgram-1 and
test-cluster-dgram-2, in order to eliminate the
possibility of port collision.

PR-URL: https://github.com/nodejs/node/pull/12487
Ref: https://github.com/nodejs/node/issues/12376
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Santiago Gimeno <santiago.gimeno@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
