### PR TITLE
test: enable test-debugger-pid

### DIFF
--- a/test/parallel/test-debugger-pid.js
+++ b/test/parallel/test-debugger-pid.js
@@ -8,10 +8,9 @@ let buffer = '';
 // connect to debug agent
 const interfacer = spawn(process.execPath, ['debug', '-p', '655555']);
 
-console.error(process.execPath, 'debug', '-p', '655555');
 interfacer.stdout.setEncoding('utf-8');
 interfacer.stderr.setEncoding('utf-8');
-const onData = function(data) {
+const onData = (data) => {
   data = (buffer + data).split('\n');
   buffer = data.pop();
   data.forEach(function(line) {
@@ -25,26 +24,29 @@ let lineCount = 0;
 interfacer.on('line', function(line) {
   let expected;
   const pid = interfacer.pid;
-  if (common.isWindows) {
-    switch (++lineCount) {
-      case 1:
-        line = line.replace(/^(debug> *)+/, '');
-        const msg = 'There was an internal error in Node\'s debugger. ' +
-                    'Please report this bug.';
-        expected = `(node:${pid}) ${msg}`;
-        break;
+  switch (++lineCount) {
+    case 1:
+      expected =
+        new RegExp(`^\\(node:${pid}\\) \\[DEP0068\\] DeprecationWarning: `);
+      assert.ok(expected.test(line), `expected regexp match for ${line}`);
+      break;
+    case 2:
+      // Doesn't currently work on Windows.
+      if (!common.isWindows) {
+        expected = "Target process: 655555 doesn't exist.";
+        assert.strictEqual(line, expected);
+      }
+      break;
 
-      default:
-        return;
-    }
-  } else {
-    line = line.replace(/^(debug> *)+/, '');
-    expected = `(node:${pid}) Target process: 655555 doesn't exist.`;
+    default:
+      if (!common.isWindows)
+        assert.fail(`unexpected line received: ${line}`);
   }
-
-  assert.strictEqual(expected, line);
 });
 
 interfacer.on('exit', function(code, signal) {
   assert.strictEqual(code, 1, `Got unexpected code: ${code}`);
+  if (!common.isWindows) {
+    assert.strictEqual(lineCount, 2);
+  }
 });


### PR DESCRIPTION
Now that `node debug` is an alias for `node inspect`, it's possible that
`node-debug-pid` can run reliably. Modify for current behavior and move
from `disabled` to `parallel`.

PR-URL: https://github.com/nodejs/node/pull/12770
Reviewed-By: Jan Krems <jan.krems@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Refael Ackermann <refack@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
