### PR TITLE
src: avoid dereference without existence check

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -282,6 +282,7 @@
         return console;
       }
     });
+    setupInspectorCommandLineAPI();
   }
 
   function installInspectorConsole(globalConsole) {
@@ -308,6 +309,22 @@
       wrappedConsole[key] = globalConsole[key];
     }
     return wrappedConsole;
+  }
+
+  function setupInspectorCommandLineAPI() {
+    const { addCommandLineAPI } = process.binding('inspector');
+    if (!addCommandLineAPI) return;
+
+    const Module = NativeModule.require('module');
+    const { makeRequireFunction } = NativeModule.require('internal/module');
+    const path = NativeModule.require('path');
+    const cwd = tryGetCwd(path);
+
+    const consoleAPIModule = new Module('<inspector console>');
+    consoleAPIModule.paths =
+        Module._nodeModulePaths(cwd).concat(Module.globalPaths);
+
+    addCommandLineAPI('require', makeRequireFunction(consoleAPIModule));
   }
 
   function setupProcessFatal() {

--- a/src/env.h
+++ b/src/env.h
@@ -292,6 +292,7 @@ namespace node {
   V(context, v8::Context)                                                     \
   V(domain_array, v8::Array)                                                  \
   V(domains_stack_array, v8::Array)                                           \
+  V(inspector_console_api_object, v8::Object)                                 \
   V(jsstream_constructor_template, v8::FunctionTemplate)                      \
   V(module_load_list_array, v8::Array)                                        \
   V(pbkdf2_constructor_template, v8::ObjectTemplate)                          \

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1283,7 +1283,7 @@ void URL::Parse(const char* input,
         }
         break;
       case kNoScheme:
-        cannot_be_base = base->flags & URL_FLAGS_CANNOT_BE_BASE;
+        cannot_be_base = has_base && (base->flags & URL_FLAGS_CANNOT_BE_BASE);
         if (!has_base || (cannot_be_base && ch != '#')) {
           url->flags |= URL_FLAGS_FAILED;
           return;

--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -4,6 +4,7 @@
 #include "gtest/gtest.h"
 
 using node::url::URL;
+using node::url::URL_FLAGS_FAILED;
 
 class URLTest : public ::testing::Test {
  protected:
@@ -20,6 +21,7 @@ class URLTest : public ::testing::Test {
 TEST_F(URLTest, Simple) {
   URL simple("https://example.org:81/a/b/c?query#fragment");
 
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
   EXPECT_EQ(simple.protocol(), "https:");
   EXPECT_EQ(simple.host(), "example.org");
   EXPECT_EQ(simple.port(), 81);
@@ -32,6 +34,7 @@ TEST_F(URLTest, Simple2) {
   const char* input = "https://example.org:81/a/b/c?query#fragment";
   URL simple(input, strlen(input));
 
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
   EXPECT_EQ(simple.protocol(), "https:");
   EXPECT_EQ(simple.host(), "example.org");
   EXPECT_EQ(simple.port(), 81);
@@ -40,10 +43,17 @@ TEST_F(URLTest, Simple2) {
   EXPECT_EQ(simple.fragment(), "fragment");
 }
 
+TEST_F(URLTest, NoBase1) {
+  URL error("123noscheme");
+  EXPECT_TRUE(error.flags() & URL_FLAGS_FAILED);
+}
+
 TEST_F(URLTest, Base1) {
   URL base("http://example.org/foo/bar");
-  URL simple("../baz", &base);
+  ASSERT_FALSE(base.flags() & URL_FLAGS_FAILED);
 
+  URL simple("../baz", &base);
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
   EXPECT_EQ(simple.protocol(), "http:");
   EXPECT_EQ(simple.host(), "example.org");
   EXPECT_EQ(simple.path(), "/baz");
@@ -52,6 +62,7 @@ TEST_F(URLTest, Base1) {
 TEST_F(URLTest, Base2) {
   URL simple("../baz", "http://example.org/foo/bar");
 
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
   EXPECT_EQ(simple.protocol(), "http:");
   EXPECT_EQ(simple.host(), "example.org");
   EXPECT_EQ(simple.path(), "/baz");
@@ -63,6 +74,7 @@ TEST_F(URLTest, Base3) {
 
   URL simple(input, strlen(input), base, strlen(base));
 
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
   EXPECT_EQ(simple.protocol(), "http:");
   EXPECT_EQ(simple.host(), "example.org");
   EXPECT_EQ(simple.path(), "/baz");

--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -34,6 +34,11 @@ function checkBadPath(err, response) {
   assert(/WebSockets request was expected/.test(err.response));
 }
 
+function checkException(message) {
+  assert.strictEqual(message['exceptionDetails'], undefined,
+                     'An exception occurred during execution');
+}
+
 function expectMainScriptSource(result) {
   const expected = helper.mainScriptSource();
   const source = result['scriptSource'];
@@ -209,6 +214,142 @@ function testI18NCharacters(session) {
   ]);
 }
 
+function testCommandLineAPI(session) {
+  const testModulePath = require.resolve('../fixtures/empty.js');
+  const testModuleStr = JSON.stringify(testModulePath);
+  const printAModulePath = require.resolve('../fixtures/printA.js');
+  const printAModuleStr = JSON.stringify(printAModulePath);
+  const printBModulePath = require.resolve('../fixtures/printB.js');
+  const printBModuleStr = JSON.stringify(printBModulePath);
+  session.sendInspectorCommands([
+    [ // we can use `require` outside of a callframe with require in scope
+      {
+        'method': 'Runtime.evaluate', 'params': {
+          'expression': 'typeof require("fs").readFile === "function"',
+          'includeCommandLineAPI': true
+        }
+      }, (message) => {
+        checkException(message);
+        assert.strictEqual(message['result']['value'], true);
+      }
+    ],
+    [ // the global require has the same properties as a normal `require`
+      {
+        'method': 'Runtime.evaluate', 'params': {
+          'expression': [
+            'typeof require.resolve === "function"',
+            'typeof require.extensions === "object"',
+            'typeof require.cache === "object"'
+          ].join(' && '),
+          'includeCommandLineAPI': true
+        }
+      }, (message) => {
+        checkException(message);
+        assert.strictEqual(message['result']['value'], true);
+      }
+    ],
+    [ // `require` twice returns the same value
+      {
+        'method': 'Runtime.evaluate', 'params': {
+          // 1. We require the same module twice
+          // 2. We mutate the exports so we can compare it later on
+          'expression': `
+            Object.assign(
+              require(${testModuleStr}),
+              { old: 'yes' }
+            ) === require(${testModuleStr})`,
+          'includeCommandLineAPI': true
+        }
+      }, (message) => {
+        checkException(message);
+        assert.strictEqual(message['result']['value'], true);
+      }
+    ],
+    [ // after require the module appears in require.cache
+      {
+        'method': 'Runtime.evaluate', 'params': {
+          'expression': `JSON.stringify(
+            require.cache[${testModuleStr}].exports
+          )`,
+          'includeCommandLineAPI': true
+        }
+      }, (message) => {
+        checkException(message);
+        assert.deepStrictEqual(JSON.parse(message['result']['value']),
+                               { old: 'yes' });
+      }
+    ],
+    [ // remove module from require.cache
+      {
+        'method': 'Runtime.evaluate', 'params': {
+          'expression': `delete require.cache[${testModuleStr}]`,
+          'includeCommandLineAPI': true
+        }
+      }, (message) => {
+        checkException(message);
+        assert.strictEqual(message['result']['value'], true);
+      }
+    ],
+    [ // require again, should get fresh (empty) exports
+      {
+        'method': 'Runtime.evaluate', 'params': {
+          'expression': `JSON.stringify(require(${testModuleStr}))`,
+          'includeCommandLineAPI': true
+        }
+      }, (message) => {
+        checkException(message);
+        assert.deepStrictEqual(JSON.parse(message['result']['value']), {});
+      }
+    ],
+    [ // require 2nd module, exports an empty object
+      {
+        'method': 'Runtime.evaluate', 'params': {
+          'expression': `JSON.stringify(require(${printAModuleStr}))`,
+          'includeCommandLineAPI': true
+        }
+      }, (message) => {
+        checkException(message);
+        assert.deepStrictEqual(JSON.parse(message['result']['value']), {});
+      }
+    ],
+    [ // both modules end up with the same module.parent
+      {
+        'method': 'Runtime.evaluate', 'params': {
+          'expression': `JSON.stringify({
+            parentsEqual:
+              require.cache[${testModuleStr}].parent ===
+              require.cache[${printAModuleStr}].parent,
+            parentId: require.cache[${testModuleStr}].parent.id,
+          })`,
+          'includeCommandLineAPI': true
+        }
+      }, (message) => {
+        checkException(message);
+        assert.deepStrictEqual(JSON.parse(message['result']['value']), {
+          parentsEqual: true,
+          parentId: '<inspector console>'
+        });
+      }
+    ],
+    [ // the `require` in the module shadows the command line API's `require`
+      {
+        'method': 'Debugger.evaluateOnCallFrame', 'params': {
+          'callFrameId': '{"ordinal":0,"injectedScriptId":1}',
+          'expression': `(
+            require(${printBModuleStr}),
+            require.cache[${printBModuleStr}].parent.id
+          )`,
+          'includeCommandLineAPI': true
+        }
+      }, (message) => {
+        checkException(message);
+        assert.notStrictEqual(message['result']['value'],
+                              '<inspector console>');
+      }
+    ],
+  ]);
+}
+
 function testWaitsForFrontendDisconnect(session, harness) {
   console.log('[test]', 'Verify node waits for the frontend to disconnect');
   session.sendInspectorCommands({ 'method': 'Debugger.resume' })
@@ -231,6 +372,7 @@ function runTests(harness) {
       testSetBreakpointAndResume,
       testInspectScope,
       testI18NCharacters,
+      testCommandLineAPI,
       testWaitsForFrontendDisconnect
     ]).expectShutDown(55);
 }


### PR DESCRIPTION
Currently the URL API is only used from the JS binding, which always
initializes `base` regardless of `has_base`. Therefore, there is no
actual security risk right now, but would be had we made other C++ parts
of Node.js use this API.

An earlier version of this patch was created by Bradley Farias
<bradley.meck@gmail.com>.

PR-URL: https://github.com/nodejs/node/pull/14591
Refs: https://github.com/nodejs/node/pull/14369#discussion_r128767221
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Tobias Nießen <tniessen@tnie.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
